### PR TITLE
Add option to write output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ This tool relies on Docker's [implementation of Canonical JSON](https://github.c
 
 ## Running
 
-The `canonjson` command takes only one argument: the path to a JSON file.
+The first argument is the input JSON file, and the second is an optional output file.
 
 ```console
 $ canonjson example.json
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"},"image_token":{"env":"AZ_IMAGE_TOKEN"},"kubeconfig":{"path":"/home/.kube/config"}},"description":"An example 'thick' helloworld Cloud-Native Application Bundle","images":[{"description":"helloworld microservice","digest":"sha256:bbbbbbbbbbbb...","image":"technosophos/helloworld:0.1.2","mediaType":"application/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":1337}],"invocationImages":[{"digest":"sha256:aaaaaaaaaaaa...","image":"technosophos/helloworld:1.2.3","imageType":"docker","mediaType":"application/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":1337}],"name":"helloworld","parameters":{"backend_port":{"defaultValue":80,"maxValue":10240,"metadata":{"description":"The port that the backend will listen on"},"minValue":10,"type":"int"}},"schemaVersion":"v1.0.0-WD","version":"1.0.0"}
+
+$ canonjson example.json canonical.json
+$ cat canonical.json
 {"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"},"image_token":{"env":"AZ_IMAGE_TOKEN"},"kubeconfig":{"path":"/home/.kube/config"}},"description":"An example 'thick' helloworld Cloud-Native Application Bundle","images":[{"description":"helloworld microservice","digest":"sha256:bbbbbbbbbbbb...","image":"technosophos/helloworld:0.1.2","mediaType":"application/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":1337}],"invocationImages":[{"digest":"sha256:aaaaaaaaaaaa...","image":"technosophos/helloworld:1.2.3","imageType":"docker","mediaType":"application/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":1337}],"name":"helloworld","parameters":{"backend_port":{"defaultValue":80,"maxValue":10240,"metadata":{"description":"The port that the backend will listen on"},"minValue":10,"type":"int"}},"schemaVersion":"v1.0.0-WD","version":"1.0.0"}
 ```

--- a/canonjson.go
+++ b/canonjson.go
@@ -9,18 +9,19 @@ import (
 )
 
 func main() {
+	const argErr = "The first argument is the input JSON file, and the second is an optional output file."
 	if len(os.Args) < 2 {
-		fail("the path to a JSON file is required")
+		fail(argErr)
 	}
 
-	file := os.Args[1]
-	if fi, err := os.Stat(file); err != nil {
-		fail("no such file: %s", file)
+	inputFile := os.Args[1]
+	if fi, err := os.Stat(inputFile); err != nil {
+		fail("no such file: %s", inputFile)
 	} else if fi.IsDir() {
-		fail("%s is a directory. JSON file required", file)
+		fail("%s is a directory. JSON file required", inputFile)
 	}
 
-	data, err := ioutil.ReadFile(file)
+	data, err := ioutil.ReadFile(inputFile)
 	if err != nil {
 		fail(err.Error())
 	}
@@ -34,8 +35,24 @@ func main() {
 	if err != nil {
 		fail(err.Error())
 	}
-	fmt.Println(string(out))
 
+	if len(os.Args) == 2 {
+		fmt.Println(string(out))
+	} else if len(os.Args) == 3 {
+		outputFile := os.Args[2]
+		f, err := os.Create(outputFile)
+		if err != nil {
+			fail("cannot create output file %v: %v", outputFile, err)
+		}
+		defer f.Close()
+
+		_, err = f.Write(out)
+		if err != nil {
+			fail(err.Error())
+		}
+	} else {
+		fail(argErr)
+	}
 }
 
 func fail(msg string, v ...interface{}) {


### PR DESCRIPTION
This PR adds an optional argument to write the output to a file.
There are two reasons for adding this:

- this allows writing to file across operating systems
- when writing to the console, a new line is appended, which makes things easier to see / copy when needed. However, when directly redirecting the output to a file, the new line means the file is no longer in canonical JSON form.

An easier fix could be to replace `fmt.Println` with `fmt.Printf` - and redirecting to a file would work fine (although not idiomatic across operating systems).